### PR TITLE
Swift Package Manager support

### DIFF
--- a/Mute/Classes/Mute.swift
+++ b/Mute/Classes/Mute.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import AudioToolbox
+import UIKit
 
 @objcMembers
 public class Mute: NSObject {
@@ -67,12 +68,29 @@ public class Mute: NSObject {
 
     /// Library bundle
     private static var bundle: Bundle {
-        guard let path = Bundle(for: Mute.self).path(forResource: "Mute", ofType: "bundle"),
-            let bundle = Bundle(path: path) else {
-            fatalError("Mute.bundle not found")
+        if let path = Bundle(for: Mute.self).path(forResource: "Mute", ofType: "bundle"),
+           let bundle = Bundle(path: path) {
+            return bundle
         }
 
-        return bundle
+        let spmBundleName = "Mute_Mute"
+
+        let candidates = [
+            // Bundle should be present here when the package is linked into an App.
+            Bundle.main.resourceURL,
+
+            // Bundle should be present here when the package is linked into a framework.
+            Bundle(for: Mute.self).resourceURL
+        ]
+
+        for candidate in candidates {
+            let bundlePath = candidate?.appendingPathComponent(spmBundleName + ".bundle")
+            if let bundle = bundlePath.flatMap(Bundle.init(url:)) {
+                return bundle
+            }
+        }
+
+        fatalError("Mute.bundle not found")
     }
 
     /// Mute sound url path

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "Mute",
+    platforms: [.iOS(.v9)],
+    products: [.library(name: "Mute", targets: ["Mute"])],
+    targets: [.target(name: "Mute", path: "Mute", resources: [.copy("Assets/mute.aiff")])]
+)


### PR DESCRIPTION
Adds [Swift Package Manager](https://swift.org/package-manager/) support.

The bundle URL determination logic is taken directly from the [code generated by the Swift Package Manager](https://developer.apple.com/documentation/swift_packages/bundling_resources_with_a_swift_package)