### PR TITLE
Outside of interval mute checking

### DIFF
--- a/Mute/Classes/Mute.swift
+++ b/Mute/Classes/Mute.swift
@@ -139,7 +139,12 @@ public class Mute: NSObject {
 
     // MARK: Methods
 
-    /// Schedueles mute sound to be played in 1 second
+    /// Starts a mute check outside the `checkInterval`.
+    public func check() {
+        playSound()
+    }
+
+    /// Schedules mute sound to be played in 1 second
     private func schedulePlaySound() {
         /// Don't schedule a new one if we already have one queued
         if self.isScheduled { return }


### PR DESCRIPTION
Add a `public` method that allows for updating the mute status outside of the scheduled interval. 
This assists in cases where the mute status needs to be updated sooner than the minimum 0.5 second interval